### PR TITLE
Move setting of version into build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,6 @@ plugins {
     id 'groovy'
 }
 
-version = '0.0.1-SNAPSHOT'
-
 apply plugin: 'com.blackducksoftware.integration.solution'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=0.0.1-SNAPSHOT


### PR DESCRIPTION
Move setting of version into build.gradle to leverage existing RelEng libraries which read gradle.properties